### PR TITLE
send file with it's name or special name

### DIFF
--- a/gapbot/client/methods/extra/upload.py
+++ b/gapbot/client/methods/extra/upload.py
@@ -11,7 +11,7 @@ class Upload(BaseClient):
             send_result = self._send(
                 method='upload',
                 data={'chat_id': chat_id, 'desc': desc},
-                files={file_type: (file_name or 'file', file.read())}
+                files={file_type: (file_name or os.path.basename(file.name), file.read())}
             ).json()
             send_result['desc'] = desc
             return json_dumps(send_result)


### PR DESCRIPTION
بازم ممنون از این قابلیتی که گزاشتید
اما بنظرم اینطوری شاید بهتر باشه بنویسید.
چون اگر کسی اسمی انتخاب نکرد کتابخونه شما بیاد اسم فایلی که طرف میخواد ارسال کنه رو بزاره بنظرم منطقی تر هستش!
چون ربات تلگرام و سروش هم همینجوری هستش.منطقی نیست اگر فایلی بخواد ارسال بشه و اسمی براش انتخاب نشه ،این کد بیاد اسم اونو 
file
بنویسه و ارسال کنه!.تو اندروید این فایل هارو تشخیص نمیده و طرف مجبوره بره اسم فایل رو تغییر به تا باز کنه
البته این نکته رو بصورت نظر فرستادم.چون با گیتهاب تازه اشنا شدم .نمیدونم  اون نظرم کجا هستش 🤣